### PR TITLE
Use long form php open tags.

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 // Your elastic search server
 $elasticsearch_server = "elasticsearch1:9200";

--- a/loader2.php
+++ b/loader2.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include 'config.php';
 $real_timezone = date_default_timezone_get();
 


### PR DESCRIPTION
Switched to long form php open tags to work on my servers that all use short_open_tag=0 in php.ini.
