### PR TITLE
Word break in more places.

### DIFF
--- a/js/ajax.js
+++ b/js/ajax.js
@@ -473,7 +473,7 @@ function mFields(field) {
 
 
 function wbr(str, num) {
-    return str.replace(RegExp("(\\w{" + num + "})(\\w)", "g"), function (all, text, char) {
+    return str.replace(RegExp("(\\w{" + num + "}|[:;,])([\\w\"'])", "g"), function (all, text, char) {
         return text + "<wbr>&#8203;" + char;
     });
 }


### PR DESCRIPTION
Insert breaking space after colon, semicolon and comma if followed by by
a word char, single quote or double quote.

This helps with some logs I have that have message bodies which contain long json encoded parts that don't have enough consecutive word chars to trigger the prior soft breaking behavior.
