### PR TITLE
Make default search index configurable.

### DIFF
--- a/config.php
+++ b/config.php
@@ -13,7 +13,7 @@ $KIBANA_CONFIG = array(
 
     // You may wish to insert a default search which all user searches
     // must match. For example @source_host:www1 might only show results
-    // from www1. 
+    // from www1.
     'filter_string' => '',
 
     // When searching, Kibana will attempt to only search indices
@@ -46,7 +46,7 @@ $KIBANA_CONFIG = array(
         '@source',
     ),
 
-    // You probably don't want to touch anything below this line 
+    // You probably don't want to touch anything below this line
     // unless you really know what you're doing
 
     // Primary field. By default Elastic Search has a special
@@ -54,6 +54,9 @@ $KIBANA_CONFIG = array(
     // Dropping _all can reduce index size significantly. If you do that
     // you'll need to change primary_field to be '@message'
     'primary_field' => '_all',
+
+    // Default Elastic Search index to query
+    'default_index' => '_all',
 
     // default search settings
     'default_search' => array(

--- a/loader2.php
+++ b/loader2.php
@@ -18,10 +18,15 @@ class LogstashLoader {
 
     /**
      * Index(es) to select from.
-     * _all is used by default.
+     *
+     * When config['smart_index'] is true we will try to guess the exact index
+     * paritions to search. If this list turns out to be longer than
+     * config['smart_index_limit'] or if smart index is disabled we will
+     * search using config['default_index'] instead.
+     *
      * @var string
      */
-    protected $index = '_all';
+    protected $index;
 
 
     /**
@@ -30,6 +35,7 @@ class LogstashLoader {
      */
     public function __construct ($config = array()) {
         $this->config = $config;
+        $this->index = $this->config['default_index'];
     }
 
 


### PR DESCRIPTION
This small patch allows setting the default index name for searches in the
config.php file.

When using an elasticsearch server with a single logstash index (not
partitioned by day) and additional indexes that are not related to logstash
performance can be improved slightly by querying specific indexes rather than
`_all`.
