### PR TITLE
Use a full path for importing the configuration.

### DIFF
--- a/loader2.php
+++ b/loader2.php
@@ -1,12 +1,27 @@
 <?php
-include 'config.php';
+
+if (!defined('KIBANA_CONFIG_FILE')) {
+    // KIBANA_CONFIG_FILE is the path to the file that defines the
+    // $KIBANA_CONFIG configuration array.
+    // The default value will look for the file in the same directory as this
+    // script.
+
+    // allow overriding the config file via an environment variable.
+    $config_path = getenv('KIBANA_CONFIG_FILE');
+    if (empty($config_path)) {
+        $config_path = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'config.php';
+    }
+
+    define('KIBANA_CONFIG_FILE', $config_path);
+}
+require_once KIBANA_CONFIG_FILE;
 
 /**
  * Handle requests for Logstash data via JSON requests.
  *
  * @author Rashid Khan <flipwork #logstash irc.freenode.net>
  * @copyright Copyright 2011 Rashid Khan
- * @license BSD 2 Clause <http://www.opensource.org/licenses/BSD-2-Clause> 
+ * @license BSD 2 Clause <http://www.opensource.org/licenses/BSD-2-Clause>
  */
 class LogstashLoader {
 


### PR DESCRIPTION
The `include 'config.php';` directive can be problematic if you are hosting
Kibana inside a vhost that has other php components and config.php in the
default search path is not the config.php that belongs to Kibana.

The defaulthvior  will make sure that config.php is loaded from the same
directory reguardless of search path by providing a full-qualifed path to the
file.

Additionally the change allows the apache config, .htaccess or a bootstrap
script to specify an alternate location for the config file by setting an
environment variable. This is nice if you have the sort of Ops team that
punches you in the face when you mix configuration and code in the same
directory. :)
