### PR TITLE
Limit esTotalDocumentCount if default_index is supplied

### DIFF
--- a/loader2.php
+++ b/loader2.php
@@ -600,12 +600,16 @@ class LogstashLoader {
 
     $indices = $result->indices;
     $totaldocs = 0;
-    foreach ($indices as $index) {
-      $totaldocs += $index->docs->num_docs;
+    if ($this->config['default_index'] == "_all") {
+      foreach ($indices as $index) {
+        $totaldocs += $index->docs->num_docs;
+      }
+    } else {
+      $index = $this->config['default_index'];
+      $totaldocs = $indices->$index->docs->num_docs;
     }
     return $totaldocs;
   } //end esTotalDocumentCount
-
 
   /**
    * Get a list of all indices that fall within the given time range.


### PR DESCRIPTION
By default Kibana shows the total number of indexed documents at the top of the page for every index. If Kibana is limited to a single index it may be better to display the number of documents in that index explicitly. 

Added simple if statement to see if default_index was changed from _all and limited the documents counted to that specific index if set.
