### PR TITLE
Prevent bad wildcard search terms from being used when flag is set & FAQ additions

### DIFF
--- a/README
+++ b/README
@@ -41,3 +41,22 @@ in PHP. I'm open to other suggestions though.
 
 Q: Where can I get some help with this?
 A: Find me on Freenode - flipwork in #logstash
+
+Q: Why do come results not show up when I search for a string I know is in
+the elasticsearch indexes?
+A: If you are searching analyzed fields, which is the default in ES for string
+fields, remember that they are broken down into terms.  For instance, a search
+for "test" will match records containing test@bleh.com, since @ is a term
+boundary and is broken down into "test" and "bleh.com".  However, this will NOT
+match records containing blah@test.com because "test.com" is the full term and
+you are searching for an exact match.  You would need to use test* to match both
+of these records.  Note you may also want to configure the ES analyze behavior
+for certain fields if this is not the desired behavior.  Helpful References:
+
+  http://www.elasticsearch.org/guide/reference/mapping/core-types.html
+  http://www.elasticsearch.org/guide/reference/api/admin-indices-templates.html
+
+Q: Is there any way to prevent queries which perform full index scans of my
+elasticsearch cluster?
+A: Yes.  Set the 'disable_fullscan' to 'true' and search terms beginning with
+an elasticsearch wildcard (* or ?) will be stripped of the wildcard.

--- a/config.php
+++ b/config.php
@@ -85,4 +85,8 @@ $KIBANA_CONFIG = array(
 
 
   'local_timezone' => date_default_timezone_get(),
+
+  // Prevent wildcard search terms which result in extremely slow queries
+  // See: http://www.elasticsearch.org/guide/reference/query-dsl/wildcard-query.html
+  'disable_fullscan' => false,
   );

--- a/kibana.spec
+++ b/kibana.spec
@@ -1,0 +1,48 @@
+%define debug_package %{nil}
+
+Name:           kibana
+Version:        0.1.5
+Release:        1%{?dist}
+Summary:        logstash is a tool for managing events and logs.
+
+Group:          System Environment/Daemons
+License:        MIT
+URL:            http://rashidkpc.github.com/Kibana/
+Source0:        %{name}-%{version}.tar.gz
+
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildArch:      noarch
+
+Requires:       php >= 5.2
+
+%description
+Kibana is an open source (MIT License), browser based interface to Logstash and ElasticSearch
+
+%prep
+rm -rf "${RPM_BUILD_ROOT}"
+mkdir -p "${RPM_BUILD_ROOT}/var/www/html/%{name}"
+
+%build
+# do nothing
+
+%install
+# untar kibana into the document root
+cd ${RPM_BUILD_ROOT}
+tar -zxvf %SOURCE0 --strip-components 1 -C ${RPM_BUILD_ROOT}/var/www/html/%{name}
+
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/httpd/conf.d
+install -m 644 $RPM_SOURCE_DIR/kibana-httpd.conf \
+        $RPM_BUILD_ROOT%{_sysconfdir}/httpd/conf.d/kibana.conf
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+/var/www/html
+%config(noreplace) /var/www/html/%{name}/config.php
+%config(noreplace) /etc/httpd/conf.d/kibana.conf
+
+%changelog
+* Fri Apr 06 2012 David Castro arimus@gmail.com 1.1.0
+- Initial spec

--- a/loader2.php
+++ b/loader2.php
@@ -142,7 +142,13 @@ class LogstashLoader {
       $last_char = "";
       for ($i=0; $i < strlen($search); $i++) {
         if ($search[$i] == "*" || $search[$i] == "?") {
-          if ($last_char == "" || ctype_alnum($last_char)) {
+	  /**
+	   * if the wildcard isn't at the beginning of the term (not first 
+	   * character in search, not preceded by whitespace, not first
+	   * character after a query component), then add it to the list 
+           */
+          $bad_chars = array('(', ':', '"', '\'', ' ', '\t', ',');
+          if ($last_char != "" && !in_array($last_char, $bad_chars)) {
             $sanitized_search .= $search[$i];
             $last_char = $search[$i];
           }


### PR DESCRIPTION
These were issues I ran into while using Kibana as a front-end for an ES instance of about 500M records and growing.  These types of searches will bring a server to it's knees for minutes if a users searches with prepended wildcards.  The FAQ additions were related questions I had and subsequently answered, which I thought would be useful as well.
