### PR TITLE
Added functionality to allow configuration of fields that are displayed by default.

### DIFF
--- a/config.php
+++ b/config.php
@@ -67,6 +67,12 @@ $KIBANA_CONFIG = array(
     '@source',
   ),
 
+  // Set the fields to display by default. If nothing, then just
+  // '@message' is displayed.
+  'default_display_fields' => array(
+	'@message',
+  ),
+
   // You probably don't want to touch anything below this line
   // unless you really know what you're doing
 

--- a/loader2.php
+++ b/loader2.php
@@ -404,7 +404,11 @@ class LogstashLoader {
         }
         //sort($return->all_fields);
     }
-    if (sizeof($req->fields) == 0) $req->fields = array('@message');
+    if (sizeof($req->fields) == 0 && $this->config['default_display_fields']) {
+        $req->fields = $this->config['default_display_fields'];
+    } else if (sizeof($req->fields) == 0) {
+        $req->fields = array('@message');
+    }
     $return->fields_requested = $req->fields;
     $return->elasticsearch_json = json_encode($query);
 


### PR DESCRIPTION
I love Kibana, but the one thing it was missing for me was the ability to specify which fields are displayed by default. I use it for examining syslog messages, so just having the Timestamp and the @message fields aren't enough for a default view. 

I needed the functionality to be able to show a few more fields (in my case, things like syslog_severity and @source_host), so I wrote a patch to be able to configure this functionality in the config file.

If it isn't specified, it falls back to the standard setup of only displaying @message.
