### PR TITLE
Add Basic Auth via Sinatra

### DIFF
--- a/kibana.rb
+++ b/kibana.rb
@@ -41,6 +41,10 @@ helpers do
 
 end
 
+use Rack::Auth::Basic, "Restircted Area" do |username, password|
+  [username, password] == ['admin', 'admin']
+end
+
 get '/' do
   send_file File.join(settings.public_folder, 'index.html')
 end


### PR DESCRIPTION
Added Basic authentication from Sinatra FAQ:
http://www.sinatrarb.com/faq.html#auth

Code starts on line 44 of Kibana.rb:
use Rack::Auth::Basic, "Restircted Area" do |username, password|
  [username, password] == ['admin', 'admin']
end
