### PR TITLE
Git clone needed to point to another url to work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ It has all the same great features, but its even easier to setup, use and hack
 on. Find it here: https://github.com/rashidkpc/Kibana/tree/kibana-ruby
 
 To clone the kibana-ruby branch use:   
-git clone --branch=kibana-ruby git@github.com:rashidkpc/Kibana.git
+git clone --branch=kibana-ruby https://github.com/rashidkpc/Kibana.git
 
 IMPORTANT: The master branch will soon be replaced with the kibana-ruby branch
 


### PR DESCRIPTION
It was previously set to be used by someone who logged in with the owners account on github.
