### PR TITLE
Fix a JS error that prevented message expansion when values are null

### DIFF
--- a/static/lib/js/shared.js
+++ b/static/lib/js/shared.js
@@ -84,7 +84,7 @@ function get_field_value(object,field,opt) {
     //return opt == 'raw' ? value : JSON.stringify(value,null,4)
     return JSON.stringify(value,null,4)
 
-  return value.toString();
+  return (value != null) ? value.toString() : '';
 }
 
 


### PR DESCRIPTION
If default fields are missing (such as full_message), value.toString() causes an error that prevents the message from expanding on click.
