### PR TITLE
a better way to do config.ru, doesn't require ruby 1.9.3

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,9 +1,17 @@
-require './kibana'
-require 'rubygems'
-require 'sinatra'
+root_dir = File.dirname(__FILE__)
+app_file = File.join(root_dir, 'kibana.rb')
+
+require app_file
+
+begin
+  require 'sinatra'
+rescue LoadError
+  require 'rubygems'
+  require 'sinatra'
+end
 
 set :environment, ENV['RACK_ENV'].to_sym
-set :app_file,     'kibana.rb'
+set :app_file, app_file
 disable :run
 
 run Sinatra::Application


### PR DESCRIPTION
I think this is a better way to do the config.ru. It allows both ruby 1.8 and 1.9 to use it correctly without special 1.9 only helpers like './app' or require_relative.
