### PR TITLE
static/lib/js/ajax.js: remove absolute path from barload.gif in getGraph()

### DIFF
--- a/static/lib/js/ajax.js
+++ b/static/lib/js/ajax.js
@@ -230,7 +230,7 @@ function getGraph(interval) {
           if (!($(".graphloading").length > 0)) {
             $('div.legend table, div.legend table td').css({
               "background-image": "url("
-                + "/images/barload.gif)",
+                + "images/barload.gif)",
               "background-size":  "100% 100%"
             });
           }


### PR DESCRIPTION
I've had to fork Kibana and make some changes to absolute paths, so I can run Kibana under a prefix URL like /Kibana.

It seems that you have fixed most of them, but trying to incorporate your changes into my fork I found this was the only thing you forgot.

Please test this before you merge, but I have a feeling its a benign change.
