### PR TITLE
Kibana ruby Splunk-like analysis

### DIFF
--- a/kibana.rb
+++ b/kibana.rb
@@ -148,7 +148,9 @@ get '/api/analyze/:field/score/:hash' do
   query   = SortedQuery.new(req.search,req.from,req.to,0,limit)
   indices = Kelastic.index_range(req.from,req.to)
   result  = KelasticMulti.new(query,indices)
-  count   = KelasticResponse.count_field(result.response,params[:field])
+  fields = Array.new
+  fields = params[:field].split(',,')
+  count   = KelasticResponse.count_field(result.response,fields)
 
   # Not sure this is required. This should be able to be handled without
   # server communication

--- a/kibana.rb
+++ b/kibana.rb
@@ -109,12 +109,14 @@ get '/api/analyze/:field/trend/:hash' do
     result_end    = KelasticMulti.new(query_end,indices_end)
   end
 
-  count_end     = KelasticResponse.count_field(result_end.response,params[:field])
+  fields = Array.new
+  fields = params[:field].split(',,')
+  count_end     = KelasticResponse.count_field(result_end.response,fields)
 
   query_begin   = SortedQuery.new(req.search,req.from,req.to,0,limit,'@timestamp','asc')
   indices_begin = Kelastic.index_range(req.from,req.to).reverse
   result_begin  = KelasticMulti.new(query_begin,indices_begin)
-  count_begin   = KelasticResponse.count_field(result_begin.response,params[:field])
+  count_begin   = KelasticResponse.count_field(result_begin.response,fields)
 
 
 

--- a/lib/clientrequest.rb
+++ b/lib/clientrequest.rb
@@ -22,6 +22,10 @@ class ClientRequest
     @request = JSON.parse(Base64.decode64(hash))
 
     @search = @request['search']
+    if @search != "" and @search.include? "|"
+      @search = @search.strip().split('|')[0].strip()
+    end
+
     @index  = @request['index']
     @offset = @request['offset'].nil? ? 0 : @request['offset']
 

--- a/lib/kelastic.rb
+++ b/lib/kelastic.rb
@@ -335,15 +335,21 @@ class KelasticResponse
 
     # Very similar to flatten_response, except only returns an array of field
     # values, without seperating into hit objects things.
-    def collect_field_values(response,field)
+    def collect_field_values(response,fields)
       @hit_list = Array.new
+      fvs = Array.new
       response['hits']['hits'].each do |hit|
-        fv = get_field_value(hit,field)
-        if fv.kind_of?(Array)
-          @hit_list = @hit_list + fv.map(&:to_s)
-        else
-          @hit_list << fv.to_s
+        count = 0
+        fields.each do |field|
+          fv = get_field_value(hit,field) 
+          if fv.kind_of?(Array)
+            fvs[count] = fv.map(&:to_s)
+          else
+            fvs[count] = fv.to_s
+          end
+          count=count+1
         end
+        @hit_list << fvs.join('||')
       end
       @hit_list
     end

--- a/static/lib/js/ajax.js
+++ b/static/lib/js/ajax.js
@@ -346,8 +346,9 @@ function getAnalysis() {
             var basedon = 'the <strong>' +
               resultjson.hits.count + ' most recent</strong>';
           }
+          var analyze_field = window.hashjson.analyze_field.split(',,').join(' ');
           var title = '<h2>Quick analysis of ' +
-            '<strong>' + window.hashjson.analyze_field + '</strong> field ' +
+            '<strong>' + analyze_field + '</strong> field(s) ' +
             '<button class="btn tiny btn-info" ' +
             'style="display: inline-block" id="back_to_logs">back to logs' +
             '</button>' +
@@ -429,7 +430,12 @@ function analysisTable(resultjson) {
     var metric = {},
     object = resultjson.hits.hits[obj];
     metric['Rank'] = i+1;
-    metric[window.hashjson.analyze_field] = object.id;
+    var idv = object.id.split('||');
+    var fields = window.hashjson.analyze_field.split(',,');
+    for (var count=0;count<fields.length;count++) {
+      metric[fields[count]]=idv[count];
+    }
+    var analyze_field = fields.join(' ')
     metric['Count'] = object.count;
     metric['Percent'] =  Math.round(
       metric['Count'] / resultjson.hits.count * 10000
@@ -444,9 +450,9 @@ function analysisTable(resultjson) {
       }
     }
     metric['Action'] =  "<span class='raw'>" + object.id + "</span>"+
-      "<i data-mode='' data-field='" + window.hashjson.analyze_field + "' "+
+      "<i data-mode='' data-field='" + analyze_field + "' "+
         "class='msearch icon-search icon-large jlink'></i> " +
-      "<i data-mode='analysis' data-field='"+window.hashjson.analyze_field+"' "+
+      "<i data-mode='analysis' data-field='"+analyze_field+"' "+
         "class='msearch icon-cog icon-large jlink'></i>";
 
     tblArray[i] = metric;
@@ -887,6 +893,19 @@ $(function () {
       window.hashjson.timeframe = $('#timeinput').val();
     }
 
+   var pattern=/^(.*)\|([^"']*)$/;
+   if (pattern.test(window.hashjson.search) == true) {
+      var results = window.hashjson.search.match(pattern);
+      var search = $.trim(results[1]);
+      var fields = results[2].split(' ');
+      var field = fields.slice(2).join(',,');
+      var mode = fields[1];
+
+
+      window.hashjson.mode = mode;
+      window.hashjson.analyze_field = field;
+    }
+
     if (window.location.hash == "#" + JSON.stringify(window.hashjson)) {
       pageload(window.location.hash);
     } else {
@@ -1290,6 +1309,11 @@ function bind_clicks() {
   // Go back to the logs
   $("#logs").delegate("button#back_to_logs", "click",
     function () {
+      var pattern=/^(.*)\|([^"']*)$/;
+      if (pattern.test(window.hashjson.search) == true) {
+         var results = window.hashjson.search.match(pattern);
+         window.hashjson.search = $.trim(results[1]);
+      }
       window.hashjson.mode = '';
       window.hashjson.graphmode = 'count';
       window.hashjson.analyze_field = '';

--- a/static/lib/js/ajax.js
+++ b/static/lib/js/ajax.js
@@ -337,6 +337,7 @@ function getAnalysis() {
         }
 
         setMeta(resultjson.hits.total);
+        var analyze_field = window.hashjson.analyze_field.split(',,').join(' ');
         switch (window.hashjson.mode) {
         case 'score':
           if (resultjson.hits.count == resultjson.hits.total) {
@@ -346,7 +347,6 @@ function getAnalysis() {
             var basedon = 'the <strong>' +
               resultjson.hits.count + ' most recent</strong>';
           }
-          var analyze_field = window.hashjson.analyze_field.split(',,').join(' ');
           var title = '<h2>Quick analysis of ' +
             '<strong>' + analyze_field + '</strong> field(s) ' +
             '<button class="btn tiny btn-info" ' +
@@ -365,7 +365,7 @@ function getAnalysis() {
         case 'trend':
           var basedon = "<strong>" + resultjson.hits.count + "</strong>";
           var title = '<h2>Trend analysis of <strong>' +
-            window.hashjson.analyze_field + '</strong> field ' +
+            analyze_field + '</strong> field ' +
             '<button class="btn tiny btn-info" ' +
             'style="display: inline-block" id="back_to_logs">back to logs' +
             '</button>' +
@@ -381,7 +381,7 @@ function getAnalysis() {
           break;
         case 'mean':
           var title = '<h2>Statistical analysis of <strong>' +
-            window.hashjson.analyze_field + '</strong> field ' +
+            analyze_field + '</strong> field ' +
             '<button class="btn tiny btn-info" ' +
             'style="display: inline-block" id="back_to_logs">back to logs' +
             '</button>' +

--- a/static/lib/js/ajax.js
+++ b/static/lib/js/ajax.js
@@ -779,10 +779,26 @@ function mSearch(field, value, mode) {
     window.hashjson.mode = mode;
     window.hashjson.analyze_field = '';
   }
-  var glue = $('#queryinput').val() != "" ? " AND " : " ";
-  var query = field + ":" + "\"" + addslashes(value.toString()) + "\"";
-
-  window.hashjson.search = $('#queryinput').val() + glue + query;
+  var pattern=/^(.*)\|([^"']*)$/;
+  var queryinput=$('#queryinput').val();
+  if (pattern.test(queryinput) == true) {
+    var results = queryinput.match(pattern);
+    var queryinput = $.trim(results[1]);
+    var fields = $.trim(results[2]).split(' ').slice(1);
+    var values = value.toString().split('||');
+    var query = '';
+    var glue = ''
+    for (var count=0;count<fields.length;count++) {
+      value=values[count];
+      field=fields[count];
+      query = query + glue + field + ":" + "\"" + addslashes(value.toString()) + "\"";
+      glue = " AND ";
+    }
+  } else {
+    var query = field + ":" + "\"" + addslashes(value.toString()) + "\"";
+  }
+  var glue = queryinput != "" ? " AND " : " ";
+  window.hashjson.search = queryinput + glue + query;
   setHash(window.hashjson);
   scroll(0, 0);
 }

--- a/static/lib/js/ajax.js
+++ b/static/lib/js/ajax.js
@@ -897,9 +897,9 @@ $(function () {
    if (pattern.test(window.hashjson.search) == true) {
       var results = window.hashjson.search.match(pattern);
       var search = $.trim(results[1]);
-      var fields = results[2].split(' ');
-      var field = fields.slice(2).join(',,');
-      var mode = fields[1];
+      var fields = $.trim(results[2]).split(' ');
+      var field = fields.slice(1).join(',,');
+      var mode = fields[0];
 
 
       window.hashjson.mode = mode;


### PR DESCRIPTION
Excellent work on this project, thank you.

I've incorporated @r-duran's changes (which added support for using a | to indicate a mode), and enhanced them to support multiple fields, so the following yields an analysis incoporating both clienthost and request:
    @type:"nginx_web" AND response:"404" | trend clienthost request

I've addressed somewhat the concern your raised about the query containing "|" pipes by using a regex to split on the first | char after which there are no more ' or " chars.
