### PR TITLE
Make array values visible.

### DIFF
--- a/static/lib/js/shared.js
+++ b/static/lib/js/shared.js
@@ -87,7 +87,21 @@ function get_field_value(object,field,opt) {
   if(value === null)
     return ''
   if($.isArray(value))
-    return opt == 'raw' ? value : value.toString();
+    if (opt == 'raw') {
+      return value;
+    }
+    else {
+        var complex = false;
+        $.each(value, function(index, el) {
+            if (typeof(el) == 'object') {
+                complex = true;
+            }
+        })
+        if (complex) {
+            return JSON.stringify(value, null, 4);
+        }
+        return value.toString();
+    }
   if(typeof value === 'object' && value != null)
     // Leaving this out for now
     //return opt == 'raw' ? value : JSON.stringify(value,null,4)


### PR DESCRIPTION
This is similar to cae6e4ab43 amd issues #70 and #44 as
if you have an Array of hashes, it is currently
printed as [Object, Object, Object]..

This change makes it get printed as pretty JSON instead

Note however that if you have an array of non-objects, then
value.toString() will be called instead - allowing you to search
on the array contents from the UI for simple fields.
