### PR TITLE
Use plain Net::HTTP instead of Curb

### DIFF
--- a/kibana.gemspec
+++ b/kibana.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |gem|
 gem.add_runtime_dependency 'sinatra'
 gem.add_runtime_dependency 'json'
 gem.add_runtime_dependency 'fastercsv'
-gem.add_runtime_dependency 'curb'
 gem.add_runtime_dependency 'tzinfo'
 gem.add_runtime_dependency 'settingslogic'
 


### PR DESCRIPTION
Like talked in [issue 107](https://github.com/rashidkpc/Kibana/issues/107), let's skip the heavy Curb dependency which requires build toolchain and *-dev libs and other sacrifices.
