### PR TITLE
Set headers to allow Kibana to be loaded in an iFrame from a different origin

### DIFF
--- a/KibanaConfig.rb
+++ b/KibanaConfig.rb
@@ -110,4 +110,7 @@ module KibanaConfig
   # Prevent wildcard search terms which result in extremely slow queries
   # See: http:#www.elasticsearch.org/guide/reference/query-dsl/wildcard-query.html
   Disable_fullscan = false
+
+  # Set headers to allow kibana to be loaded in an iframe from a different origin.
+  Allow_iframed = false
 end

--- a/kibana.rb
+++ b/kibana.rb
@@ -44,7 +44,7 @@ helpers do
 end
 
 get '/' do
-  headers "X-Frame-Options" => "allow","X-XSS-Protection" => "0"
+  headers "X-Frame-Options" => "allow","X-XSS-Protection" => "0" if KibanaConfig::Allow_iframed
   send_file File.join(settings.public_folder, 'index.html')
 end
 

--- a/kibana.rb
+++ b/kibana.rb
@@ -44,6 +44,7 @@ helpers do
 end
 
 get '/' do
+  headers "X-Frame-Options" => "allow","X-XSS-Protection" => "0"
   send_file File.join(settings.public_folder, 'index.html')
 end
 


### PR DESCRIPTION
We have created an internal dashboard where we load different reporting/monitoring tools in a frame. Kibana by default sets these headers, which don't allow this:

```
X-Frame-Options:sameorigin
X-XSS-Protection:1; mode=block
```

If KibanaConfig::Allow_iframed is true, set them to this:

```
X-Frame-Options:allow
X-XSS-Protection:0
```
