### PR TITLE
Updated the terms facet to support multiple fields.  Corrected the terms facet index count.

### DIFF
--- a/kibana.rb
+++ b/kibana.rb
@@ -151,7 +151,9 @@ end
 get '/api/analyze/:field/terms/:hash' do
   limit   = KibanaConfig::Analyze_show
   req     = ClientRequest.new(params[:hash])
-  query   = TermsFacet.new(req.search,req.from,req.to,params[:field])
+  fields = Array.new
+  fields = params[:field].split(',,')
+  query   = TermsFacet.new(req.search,req.from,req.to,fields)
   indices = Kelastic.index_range(req.from,req.to,KibanaConfig::Facet_index_limit)
   result  = KelasticMultiFlat.new(query,indices)
 

--- a/lib/query.rb
+++ b/lib/query.rb
@@ -149,14 +149,26 @@ end
 class TermsFacet < Query
   def initialize(question, from, to, field, limit = KibanaConfig::Analyze_show)
     super(question, from, to)
-    @query['facets'] = {
-      "terms" => {
-        "terms" => {
-          "field" => field,
-          "size"  => limit
+    if (field.kind_of?(Array))
+	script = "doc['" + field.join("'].value + '||' + doc['") + "'].value"
+        @query['facets'] = {
+          "terms" => {
+            "terms" => {
+              "script" => script,
+              "size"  => limit
+          }
         }
       }
-    }
+    else
+      @query['facets'] = {
+        "terms" => {
+          "terms" => {
+            "field" => field,
+            "size"  => limit
+          }
+        }
+      }
+   end
   end
 end
 

--- a/static/lib/js/ajax.js
+++ b/static/lib/js/ajax.js
@@ -350,9 +350,9 @@ function getAnalysis() {
         switch (window.hashjson.mode) {
         case 'terms':
           var index_count  = $.isArray(resultjson.kibana.index) ?
-            resultjson.kibana.index : 1;
+            resultjson.kibana.index : resultjson.kibana.index.split(',').length;
           var title = '<h2>Terms Facet of ' +
-            '<strong>' + window.hashjson.analyze_field + '</strong> field ' +
+            '<strong>' + analyze_field + '</strong> field(s) ' +
             '<button class="btn tiny btn-info" ' +
             'style="display: inline-block" id="back_to_logs">back to logs' +
             '</button>' +
@@ -496,15 +496,20 @@ function termsTable(resultjson) {
     var object = resultjson.facets.terms.terms[obj],
     metric = {};
     metric['Rank'] = i+1;
-    metric[window.hashjson.analyze_field] = object.term;
+    var termv = object.term.split('||');
+    var fields = window.hashjson.analyze_field.split(',,');
+    for (var count=0;count<fields.length;count++) {
+      metric[fields[count]]=termv[count];
+    }
+    var analyze_field = fields.join(' ')
     metric['Count'] = addCommas(object.count);
     metric['Percent'] =  Math.round(
       object.count / resultjson.hits.total * 10000
       ) / 100 + '%';
     metric['Action'] =  "<span class='raw'>" + object.term + "</span>"+
-      "<i data-mode='' data-field='" + window.hashjson.analyze_field + "' "+
+      "<i data-mode='' data-field='" + analyze_field + "' "+
         "class='msearch icon-search icon-large jlink'></i> " +
-      "<i data-mode='analysis' data-field='"+window.hashjson.analyze_field+"' "+
+      "<i data-mode='analysis' data-field='"+analyze_field+"' "+
         "class='msearch icon-cog icon-large jlink'></i>";
 
     tblArray[i] = metric;
@@ -592,8 +597,8 @@ function enable_popovers() {
           "data-field="+field+"><i class='icon-list-ol'></i> Score</button>" +
           "<button class='btn btn-small analyze_btn' rel='trend' " +
           "data-field="+field+"><i class='icon-tasks'></i> Trend</button>" +
-          //"<button class='btn btn-small analyze_btn' rel='terms' " +
-          //"data-field="+field+"><i class='icon-th-list'></i> Terms</button>" +
+          "<button class='btn btn-small analyze_btn' rel='terms' " +
+          "data-field="+field+"><i class='icon-th-list'></i> Terms</button>" +
           "<button class='btn btn-small analyze_btn' rel='mean' " +
           "data-field="+field+"><i class='icon-bar-chart'></i> Stats</button>" +
         "</div>";


### PR DESCRIPTION
Just like with score and trend, you can now pass multiple fields to the terms mode.
It does terms based on the joining of the multiple fields, just like score and trend.

Also corrected the index count reported for the terms query.

The terms option is enabled by this pull, but feel free to disable it again.  There is definitely a good chance of running out of memory if the back-end isn't set up properly, or the query is too liberal.

I'm thinking that the multiple fields description would be better presented comma-separated and inside of parenthesis, as:
  Terms Facet of (website, virtual_folder) field(s)
Or perhaps dropped out completely since the heading contains that info.

Next up I'm thinking of populating the query window with the | format of the query when any of the analysis buttons are clicked in the micro analysis window.
