### PR TITLE
Support multi-dot fields AND nested objects

### DIFF
--- a/lib/kelastic.rb
+++ b/lib/kelastic.rb
@@ -348,7 +348,7 @@ class KelasticResponse
       if !obj[field].nil?
         obj[field]
       elsif field =~ /(.*?)\.(.*)/
-        if !obj[$1][$2].nil?
+        if !obj[$1].nil? and !obj[$1][$2].nil?
           obj[$1][$2]
         elsif !obj[$1].nil?
           recurse_field_dots(obj[$1],$2)

--- a/lib/kelastic.rb
+++ b/lib/kelastic.rb
@@ -340,12 +340,19 @@ class KelasticResponse
 
     # Retrieve a field value from a hit
     def get_field_value(hit,field)
-      if field =~ /(.*?)\.(.*)/
-        if defined? hit['_source'][$1][$2]
-          hit['_source'][$1][$2]
+      recurse_field_dots(hit['_source'],field)
+    end
+
+    # Recursively check for multi-dot fields and nested arrays
+    def recurse_field_dots(obj,field)
+      if !obj[field].nil?
+        obj[field]
+      elsif field =~ /(.*?)\.(.*)/
+        if !obj[$1][$2].nil?
+          obj[$1][$2]
+        elsif !obj[$1].nil?
+          recurse_field_dots(obj[$1],$2)
         end
-      elsif defined? hit['_source'][field]
-        hit['_source'][field]
       else
         nil
       end

--- a/static/lib/js/shared.js
+++ b/static/lib/js/shared.js
@@ -119,15 +119,12 @@ function get_related_fields(json,field) {
 function recurse_field_dots(object,field) {
   var value;
   if (typeof object[field] != 'undefined')
-    value = object[field];  
-  else {
-    nested = field.match(/(.*?)\.(.*)/);
-    if (nested)
+    value = object[field];
+  else if (nested = field.match(/(.*?)\.(.*)/))
       value = (typeof object[nested[1]][nested[2]] != 'undefined') ?
         object[nested[1]][nested[2]] : recurse_field_dots(object[nested[1]],nested[2]);
-    else
-      value = null;
-  }
+  else
+    value = null;
 
   return value;
 }

--- a/static/lib/js/shared.js
+++ b/static/lib/js/shared.js
@@ -116,22 +116,25 @@ function get_related_fields(json,field) {
   return counts;
 }
 
-function get_field_value(object,field,opt) {
-  try {
-    nested = field.match(/(.*?)\.(.*)/)
-    var value;
+function recurse_field_dots(object,field) {
+  var value;
+  if (typeof object[field] != 'undefined')
+    value = object[field];  
+  else {
+    nested = field.match(/(.*?)\.(.*)/);
     if (nested)
-      value = object['_source'][nested[1]][nested[2]]
+      value = (typeof object[nested[1]][nested[2]] != 'undefined') ?
+        object[nested[1]][nested[2]] : recurse_field_dots(object[nested[1]],nested[2]);
     else
-      value = object['_source'][field]
-  } catch(e) {
-    var value = null
+      value = null;
   }
-  //var value = field.charAt(0) == '@' ?
-  //  object['_source'][field] : object['_source']['@fields'][field];
 
-  if(typeof value === 'undefined')
-    return ''
+  return value;
+}
+
+function get_field_value(object,field,opt) {
+  var value = recurse_field_dots(object['_source'],field);
+
   if(value === null)
     return ''
   if($.isArray(value))

--- a/static/lib/js/shared.js
+++ b/static/lib/js/shared.js
@@ -117,14 +117,13 @@ function get_related_fields(json,field) {
 }
 
 function recurse_field_dots(object,field) {
-  var value;
+  var value = null;
   if (typeof object[field] != 'undefined')
     value = object[field];
   else if (nested = field.match(/(.*?)\.(.*)/))
+    if(typeof object[nested[1]] != 'undefined')
       value = (typeof object[nested[1]][nested[2]] != 'undefined') ?
         object[nested[1]][nested[2]] : recurse_field_dots(object[nested[1]],nested[2]);
-  else
-    value = null;
 
   return value;
 }


### PR DESCRIPTION
Fixed get_field_value in ruby and javascript to check for multi-dot columns as well as nested objects. 
