### PR TITLE
Use a short filename when downloading RSS XML

### DIFF
--- a/kibana.rb
+++ b/kibana.rb
@@ -253,7 +253,9 @@ get '/rss/:hash/?:count?' do
   result  = KelasticMulti.new(query,indices)
   flat    = KelasticResponse.flatten_response(result.response,req.fields)
 
-  headers "Content-Type" => "application/rss+xml", "charset" => "utf-8"
+  headers "Content-Type"        => "application/rss+xml",
+          "charset"             => "utf-8",
+          "Content-Disposition" => "inline; filename=kibana_rss_#{Time.now.to_i}.xml"
 
   content = RSS::Maker.make('2.0') do |m|
     m.channel.title = "Kibana #{req.search}"


### PR DESCRIPTION
Sometimes the hash is too long and won't save on the local machine
