### PR TITLE
Use jquery text calls to sanitize unsafe inputs to prevent XSS attacks

### DIFF
--- a/static/lib/js/stream.js
+++ b/static/lib/js/stream.js
@@ -32,7 +32,7 @@ function pageload(hash) {
     window.hashjson.fields = window.hashjson.fields.length > 0 ?
       window.hashjson.fields : new Array('@message');
 
-    $('#query h4').html(window.hashjson.search);
+    $('#query h4').text(window.hashjson.search);
 
     getStream();
 
@@ -58,8 +58,6 @@ function getStream() {
       window.i++;
       var fields = window.hashjson.fields
       var has_time = false;
-      var header = "";
-      var str = "";
       var id = "";
       var hit = "";
       var i = 0;
@@ -73,7 +71,7 @@ function getStream() {
           has_time = true;
         }
         if ($('#logrow_' + id).length == 0) {
-          str += "<tr id=logrow_" + id + ">";
+          var tableRow = $("<tr/>").attr('id', "logrow_" + id);
           i++;
           hash = Base64.encode(JSON.stringify(
             {
@@ -85,30 +83,29 @@ function getStream() {
               "offset":0
             }
             ));
-          str += "<td style='white-space:nowrap;'><a class=jlink href='../#"+hash+"'><i class='icon-link'></i></a> " +
-            prettyDateString(Date.parse(get_field_value(hit,'@timestamp')) + tOffset) + "</td>";
+
+          var jlink = $('<a/>').addClass('jlink').attr('href', "../#" + hash).html($('<i/>').addClass('icon-link'));
+          var linkTableData = $("<td/>").css('white-space', 'nowrap');
+          linkTableData.text(prettyDateString(Date.parse(get_field_value(hit,'@timestamp')) + tOffset)).prepend(jlink);
+          tableRow.append(linkTableData);
           for (var field in fields) {
-            str += "<td>" +
-              get_field_value(hit,fields[field]) + "</td>";
+            tableRow.append($("<td/>").text(get_field_value(hit,fields[field])));
           }
-          str += "</tr>";
+          $("#tweets tbody").prepend(tableRow);
         }
       }
-
-      $(str).prependTo('#tweets tbody');
-      $('#counter h3').fadeOut(100)
+      $('#counter h3').fadeOut(100);
       $('#counter h3').html(data.hits.total/timeframe+'/second');
-      $('#counter h3').fadeIn(500)
+      $('#counter h3').fadeIn(500);
 
       $( 'tr:gt(' + ( maxEvents ) + ')' ).fadeOut(
         "normal", function() { $(this).remove(); } );
       if(!window.hasHead) {
-        header += "<th>Time</th>";
-        for (var field in fields) {
-            header += "<th>" + fields[field] + "</th>";
-        }
         window.hasHead = true;
-        $('#tweets thead').html(header)
+        $('#tweets thead').append($("<th/>").text("Time"));
+        for (var field in fields) {
+          $('#tweets thead').append($("<th/>").text(fields[field]));
+        }
       }
     }
   });


### PR DESCRIPTION
In the stream view there are currently several XSS vulnerabilities that could be taken advantage of. This fixes all the ones I could find. To test:

Do a search in the normal page for <script>alert('asdf')</script>
Go to stream view
You'll get a browser alert window

Get a message into logstash that contains in the message <script>alert('asdf')</script>
Go to stream view
You'll get a browser alert window

This is fixed by using the jquery dom builder rather than straight str concatenation. Unsafe inputs are added to the DOM using .text calls, rather than .html to ensure they are sanitized.
