### PR TITLE
Added locals[:type] for User and Group when editing account 

### DIFF
--- a/kibana.rb
+++ b/kibana.rb
@@ -215,9 +215,11 @@ get %r{/auth/admin/([\w]+)(/[@% \w]+)?} do
         group=locals[:user_data][:username][/[^@].*/]
         locals[:group_members] = @@auth_module.group_members(group)
         locals[:allusers] = @@auth_module.users()
+	locals[:type] = "Group"
       else
         locals[:can_change_pass] = @@auth_module.respond_to?('set_password')
         locals[:user_groups] = @@auth_module.membership(locals[:user_data][:username])
+	locals[:type] = "User"
       end
     elsif mode == "newuser"
       locals[:mode] = "new"


### PR DESCRIPTION
Editing an account returned:

NoMethodError at /auth/admin/save
undefined method `empty?' for nil:NilClass

This was caused by User and Group locals[:type] not being set and passed to the POST.

POST info showed:

Variable    Value
is_admin    "on"
mode    "edit"
name    "kibana"

Instead of:

Variable    Value
is_admin    "on"
mode    "edit"
Username    "kibana"
