### PR TITLE
Updated Smart_index_pattern

### DIFF
--- a/KibanaConfig.rb
+++ b/KibanaConfig.rb
@@ -83,7 +83,7 @@ module KibanaConfig
   # date formatting like '%Y.%m.%d'.  Will accept an array of smart 
   # indexes.  
   # Smart_index_pattern = ['logstash-web-%Y.%m.%d', 'logstash-mail-%Y.%m.%d'] 
-  Smart_index_pattern = 'logstash-%Y.%m.%d.%H'
+  Smart_index_pattern = [ 'logstash-%Y.%m.%d.%H', 'logstash-%Y.%m.%d' ]
   Smart_index_step = 3600
 
   # ElasticSearch has a default limit on URL size for REST calls,


### PR DESCRIPTION
Commit af188914b0a7ece2b9bd26865e2d368f943b34ab changed the
Smart_index_pattern to use `logstash-%Y.%m.%d.%H`. The default
ElasticSearch index created by LogStash matches the pattern
`logstash-%Y.%m.%d`. This commit updates the Smart_index_pattern
setting in KibanaConfig.rb to be an array matching both patterns.
