### PR TITLE
Added check for empty password field, does not set password to blank if ...

### DIFF
--- a/kibana.rb
+++ b/kibana.rb
@@ -257,8 +257,10 @@ post '/auth/admin/save' do
       members = params[:members]
       @@auth_module.add_group(group, members)
     elsif params[:pass1] != nil
-      password = params[:pass1]
-      @@auth_module.set_password(username, password)
+      if params[:pass1] != ""
+        password = params[:pass1]
+        @@auth_module.set_password(username, password)
+      end
       user_groups = params[:user_groups]
       old_groups = @@auth_module.membership(username)
       if user_groups.nil?


### PR DESCRIPTION
Not sure what the desired effect is, but if you change a users settings right now and do not provide a new password (or their old password) it will set the password to nothing. I do see a if check to see if pass1 is nil, but it is set and empty, at least from firefox. 

Added additional check to see if it is empty, if it contains a value it will update the users password.

This does not take in to account checking to see if there is a password already set (or if the user exists). So new accounts could be set to have an empty password, this is probably not desired. 
