### PR TITLE
indexes should always be in UTC

### DIFF
--- a/lib/kelastic.rb
+++ b/lib/kelastic.rb
@@ -66,7 +66,7 @@ class Kelastic
         index_pattern = index_pattern.kind_of?(Array) ? index_pattern : [index_pattern]
         for index in index_pattern do
           begin
-            requested << from.strftime(index)
+            requested << from.getutc.strftime(index)
           end while (from += KibanaConfig::Smart_index_step) <= to
         end
 


### PR DESCRIPTION
this broke in this commit - https://github.com/rashidkpc/Kibana/commit/af188914b0a7ece2b9bd26865e2d368f943b34ab
