### PR TITLE
index_range edge case fix

### DIFF
--- a/lib/kelastic.rb
+++ b/lib/kelastic.rb
@@ -68,6 +68,7 @@ class Kelastic
           begin
             requested << from.getutc.strftime(index)
           end while (from += KibanaConfig::Smart_index_step) <= to
+          requested << to.getutc.strftime(index) unless requested.include? to.getutc.strftime(index)
         end
 
         intersection = requested & all_indices


### PR DESCRIPTION
After a new index is created and your search time range is less than
the Smart_index_step, the newest index wasn't included.
