### PR TITLE
Removed adding @ to group name since group name already has @ symbol

### DIFF
--- a/kibana.rb
+++ b/kibana.rb
@@ -240,7 +240,7 @@ end
 
 post '/auth/admin/save' do
   if params[:Groupname] != nil
-    params[:Username]= '@' + params[:Groupname]
+    params[:Username]= params[:Groupname]
   end
   username = params[:Username]
   usertags = params[:usertags]


### PR DESCRIPTION
Editing groups was causing an additional permissions type record being created for @@groupname.

This was due to groups already starting with @.
