### PR TITLE
Added an option to turn URLs into clickable links

### DIFF
--- a/KibanaConfig.rb
+++ b/KibanaConfig.rb
@@ -51,6 +51,9 @@ module KibanaConfig
   # be either stored or part of the _source field.
   Highlighted_field = "@message"
 
+  # Make URLs clickable in detailed view
+  Clickable_URLs = true
+
   # The default operator used if no explicit operator is specified.
   # For example, with a default operator of OR, the query capital of
   # Hungary is translated to capital OR of OR Hungary, and with default

--- a/kibana.rb
+++ b/kibana.rb
@@ -74,6 +74,8 @@ get '/api/search/:hash/?:segment?' do
   result.response['kibana']['time'] = {
     "from" => req.from.iso8601, "to" => req.to.iso8601}
   result.response['kibana']['default_fields'] = KibanaConfig::Default_fields
+  # Enable clickable URL links
+  result.response['kibana']['clickable_urls'] = KibanaConfig::Clickable_URLs
 
   JSON.generate(result.response)
 end

--- a/static/lib/js/ajax.js
+++ b/static/lib/js/ajax.js
@@ -133,7 +133,7 @@ function getPage() {
         // Determine fields to be displayed
         var fields = window.hashjson.fields.length == 0 ?
           resultjson.kibana.default_fields : window.hashjson.fields
-  
+
         // Create 'Columns' section
         $('#fields').html("<div class='input-prepend'>" +
           "<span class='add-on'><i class='icon-columns'></i></span>" +

--- a/static/lib/js/ajax.js
+++ b/static/lib/js/ajax.js
@@ -133,7 +133,7 @@ function getPage() {
         // Determine fields to be displayed
         var fields = window.hashjson.fields.length == 0 ?
           resultjson.kibana.default_fields : window.hashjson.fields
-
+  
         // Create 'Columns' section
         $('#fields').html("<div class='input-prepend'>" +
           "<span class='add-on'><i class='icon-columns'></i></span>" +
@@ -920,11 +920,36 @@ function details_table(objid,theme) {
     var trclass = (i % 2 == 0) ?
       'class="alt '+field_id+'_row"' : 'class="'+field_id+'_row"';
 
-    str += "<tr " + trclass + ">" +
-      "<td class='firsttd " + field_id + "_field'>" + field + "</td>" +
-      "<td style='width: 60px'>" + buttons + "</td>" +
-      '<td>' + xmlEnt(wbr(value, 10)) +
-      "</td></tr>";
+    // Are URLs clickable ?
+    if (resultjson.kibana.clickable_urls) {
+      var value = value === undefined ? "-" : value.toString();
+      // Detect URLs and inserts delimiters
+      var value = value.replace(RegExp("(https?://([-\\w\\.]+)+(:\\d+)?(/([\\w/_\\.]*(\\?\\S+)?)?)?)", "g"),
+        function (all, text, char) {
+          return "@KIBANA_LINK_START@" + text + "@KIBANA_LINK_END@";
+        }
+      );
+      var value = xmlEnt(wbr(value),10);
+      // Replace delimiters by HTML code
+      var value = value.replace(RegExp("@KIBANA_LINK_START@(.*)@KIBANA_LINK_END@", "g"), 
+        function (all, text) {
+          // Clean link
+          var stripped = text.replace( new RegExp("<del>&#8203;</del>","g"),"");
+          return "<a href='" + stripped + "'>" + text + "</a>";
+        }
+      );
+      str += "<tr " + trclass + ">" +
+	"<td class='firsttd " + field_id + "_field'>" + field + "</td>" +
+	"<td style='width: 60px'>" + buttons + "</td>" +
+	'<td>' + value +
+	"</td></tr>";
+    } else {
+      str += "<tr " + trclass + ">" +
+        "<td class='firsttd " + field_id + "_field'>" + field + "</td>" +
+        "<td style='width: 60px'>" + buttons + "</td>" +
+        '<td>' + xmlEnt(wbr(value, 10)) +
+        "</td></tr>";
+    }
 
     i++;
 


### PR DESCRIPTION
I added an option to the configuration file : "Clickable_URLs = true/false". This will turn any detected URL into a clickable link. It works with any field, but only in the detailed log panel, to avoid overloading the default view with hypertext links.
