### PR TITLE
Fix highlighting problem

### DIFF
--- a/static/lib/js/ajax.js
+++ b/static/lib/js/ajax.js
@@ -883,6 +883,7 @@ function CreateLogTable(objArray, fields, theme, enableHeader) {
         value + '</td>';
     }
     str += '</tr><tr class="hidedetails"></tr>';
+    hlfield = undefined;
     i++;
   }
 


### PR DESCRIPTION
Once hlfield is assigned the typeof hlfield check will never return true so the value never gets updated to a new one.

That means that the same message is repeated over and over once the first highlighted one has been found.

I'm no JavaScript expert (noob would be more like it) so there might be a more elegant fix for this.
