### PR TITLE
kibana-ruby-auth : LDAP fqdn suffix

### DIFF
--- a/KibanaConfig.rb
+++ b/KibanaConfig.rb
@@ -130,6 +130,8 @@ module KibanaConfig
   # Authentication options for the auth_ldap module
   Ldap_host = '127.0.0.1'
   Ldap_port = 389
+  # Adds a '@domain.local' suffix to the username when authenticating against an LDAP directory
+  # Ldap_domain_fqdn = 'domain.local'
 
   # Storage Module
   Storage_module = 'elasticsearch'  # mongo

--- a/lib/modules/auth_ldap.rb
+++ b/lib/modules/auth_ldap.rb
@@ -8,12 +8,13 @@ class AuthLDAP
     @ldap.port = (defined? config::Ldap_port) ? config::Ldap_port : 389
     @ldap_user_base = (defined? config::Ldap_user_base) ? config::Ldap_user_base : "dc=example, dc=com"
     @ldap_group_base = (defined? config::Ldap_group_base) ? config::Ldap_group_base : "dc=example, dc=com"
+    @ldap_suffix = (defined? config::Ldap_domain_fqdn) ? "@" + config::Ldap_domain_fqdn : ""
   end
 
   # Required function, authenticates a username/password
   def authenticate(username,password)
     begin
-      @ldap.auth username, password
+      @ldap.auth username + @ldap_suffix, password
       if @ldap.bind
         return true
       end


### PR DESCRIPTION
New 'Ldap_domain_fqdn' optional configuration option. It adds a @domain.fqdn suffix to the username when authenticating against an LDAP directory. Useful for authentication against Active Directory for example.
