### PR TITLE
Modified version of Kibana in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kibana (0.0.1)
+    kibana (0.2.0)
       fastercsv
       json
       sinatra


### PR DESCRIPTION
It still had 0.0.1 as version number which causes bundle install to fail.
Do note that it will need to be updated if the version of kibana goes up.
