### PR TITLE
auth and users management split

### DIFF
--- a/KibanaConfig.rb
+++ b/KibanaConfig.rb
@@ -123,6 +123,9 @@ module KibanaConfig
   # Authentication Module
   Auth_module = 'elasticsearch'
 
+  # Users and groups management Module
+  Users_module = 'elasticsearch'
+
   Auth_Admin_User  = 'kibana'
   Auth_Admin_Pass  = 'password'
   Auth_Admin_Perms  = { 'is_admin' => true, 'enabled' => true, 'tags' => ['*'] }

--- a/lib/modules/auth_elasticsearch.rb
+++ b/lib/modules/auth_elasticsearch.rb
@@ -14,32 +14,16 @@ class AuthElasticSearch
 
     puts "Initializing elasticsearch for kibana auth..."
     # Make sure the default admin user is present
-    p = lookup_user(config::Auth_Admin_User)
+    p = @@users_module.lookup_user(config::Auth_Admin_User)
     if (p == nil)
       puts "Adding default admin user #{config::Auth_Admin_User} ..."
       add_user(config::Auth_Admin_User,config::Auth_Admin_Pass)
     end
-    
-  end
-
-  def lookup_user_groups(username)
-    g = @gesm.get_record_ids_with_term("members", username)
-    return g
-  end
-
-  def lookup_user(username)
-    p = @uesm.get_by_id(username)
-    return p
-  end
-
-  def users()
-    u = @uesm.get_all('username')
-    return u.sort
   end
 
   # Required function, authenticates a username/password
   def authenticate(username,password)
-    user = lookup_user(username)
+    user = @@users_module.lookup_user(username)
     return false if not user
     salt=user['salt']
     hashpass=Digest::SHA256.hexdigest(salt + password)
@@ -48,65 +32,6 @@ class AuthElasticSearch
     end
     return false
   end
-
-  # Update the user's password
-  def set_password(username,password)
-    add_user(username,password)
-  end
-
-  def add_user(username,password)
-    salt = rand(65536)
-    salt = salt.to_s(16)
-    hashpass = Digest::SHA256.hexdigest(salt + password)
-    values = {"username" => username, "password" => hashpass, "salt" => salt}
-    result = @uesm.set_by_id(username, values)
-  end
-
-  # This update a groups list of users
-  def add_user_2group(username,group)
-    defaults = {"group" => group, "members" => "["+username+"]"}
-    result = @gesm.add_term_to_record_array(group, "members", username, defaults)
-  end
-
-  def rm_user_from_group(username,group)
-    result = @gesm.del_term_from_record_array(group, "members", username)
-  end
-
-  def add_group(group, members)
-    members = members || []
-    values = {"group" => group, "members" => members}
-    result = @gesm.set_by_id(group, values)
-  end
-
-  # Required function, returns user's groups membership
-  def membership(username)
-    g = lookup_user_groups(username)
-    return g.sort
-  end
-
-  def group_members(group)
-    g = @gesm.get_by_id(group)
-    if g and g['members']
-      return g['members'].sort
-    else
-      return []
-    end
-  end
-
-  # Required function, returns a list of all groups
-  def groups()
-    g = @gesm.get_all('group')
-    return g.sort
-  end
-
-  def del_user(name)
-    r = @gesm.del_by_id(name)
-  end
-
-  def del_group(name)
-    r = @gesm.del_by_id(name)
-  end
-
 end
 
 # Required function, returns the auth

--- a/lib/modules/auth_ldap.rb
+++ b/lib/modules/auth_ldap.rb
@@ -22,18 +22,6 @@ class AuthLDAP
     end
     return false
   end
-
-  # Required function, returns user's groups membership
-  def membership(username)
-    grlist = []
-    return grlist.uniq.sort
-  end
-
-  # Required function, returns a list of all groups
-  def groups()
-    grlist = []
-    return grlist.uniq.sort
-  end
 end
 
 # Required function, returns the auth

--- a/lib/modules/auth_pam.rb
+++ b/lib/modules/auth_pam.rb
@@ -20,39 +20,6 @@ class AuthPam
       return false
     end
   end
-
-  # Required function, returns user's groups membership
-  def membership(username)
-    grlist = []
-    begin
-      userpw = Etc.getpwnam(username)
-    rescue
-      return grlist
-    end
-    begin
-      usergr = Etc.getgrgid(userpw.gid)
-      grlist.push(usergr.name)
-    rescue
-      # This shouldn't happen, if it does it means
-      # someone was probably hand-editing the passwd/
-      # group files and messed up. 
-    end
-    Etc.group { |g|
-      if g.mem.index(username)
-        grlist.push(g.name)
-      end
-    }
-    return grlist.uniq.sort
-  end
-
-  # Required function, returns a list of all groups
-  def groups()
-    grlist = []
-    Etc.group { |g|
-      grlist.push(g.name)
-    }
-    return grlist.uniq.sort
-  end
 end
 
 # Required function, returns the auth

--- a/lib/modules/users_elasticsearch.rb
+++ b/lib/modules/users_elasticsearch.rb
@@ -1,0 +1,103 @@
+require 'lib/modules/elasticsearchmod'
+
+class UsersElasticSearch
+  # Required function, accepts a KibanaConfig object
+  def initialize(config)
+    @config = config
+    @index = 'kibana'
+    @utype = 'user'
+    @gtype = 'group'
+
+    puts "Initializing elasticsearch module"
+    @uesm = Elasticsearchmod.new(@index,@utype)
+    @gesm = Elasticsearchmod.new(@index,@gtype)
+
+    puts "Initializing elasticsearch for kibana user management..."
+    # Make sure the default admin user is present
+    p = lookup_user(config::Auth_Admin_User)
+    if (p == nil)
+      puts "Adding default admin user #{config::Auth_Admin_User} ..."
+      add_user(config::Auth_Admin_User,config::Auth_Admin_Pass)
+    end
+  end
+
+  def lookup_user_groups(username)
+    g = @gesm.get_record_ids_with_term("members", username)
+    return g
+  end
+
+  def lookup_user(username)
+    p = @uesm.get_by_id(username)
+    return p
+  end
+
+  def users()
+    u = @uesm.get_all('username')
+    return u.sort
+  end
+
+  # Update the user's password
+  def set_password(username,password)
+    add_user(username,password)
+  end
+
+  def add_user(username,password)
+    salt = rand(65536)
+    salt = salt.to_s(16)
+    hashpass = Digest::SHA256.hexdigest(salt + password)
+    values = {"username" => username, "password" => hashpass, "salt" => salt}
+    result = @uesm.set_by_id(username, values)
+  end
+
+  # This update a groups list of users
+  def add_user_2group(username,group)
+    defaults = {"group" => group, "members" => "["+username+"]"}
+    result = @gesm.add_term_to_record_array(group, "members", username, defaults)
+  end
+
+  def rm_user_from_group(username,group)
+    result = @gesm.del_term_from_record_array(group, "members", username)
+  end
+
+  def add_group(group, members)
+    members = members || []
+    values = {"group" => group, "members" => members}
+    result = @gesm.set_by_id(group, values)
+  end
+
+  # Required function, returns user's groups membership
+  def membership(username)
+    g = lookup_user_groups(username)
+    return g.sort
+  end
+
+  def group_members(group)
+    g = @gesm.get_by_id(group)
+    if g and g['members']
+      return g['members'].sort
+    else
+      return []
+    end
+  end
+
+  # Required function, returns a list of all groups
+  def groups()
+    g = @gesm.get_all('group')
+    return g.sort
+  end
+
+  def del_user(name)
+    r = @gesm.del_by_id(name)
+  end
+
+  def del_group(name)
+    r = @gesm.del_by_id(name)
+  end
+
+end
+
+# Required function, returns the users
+# class for this module.
+def get_users_module(config)
+  return UsersElasticSearch.new(config)
+end

--- a/lib/modules/users_ldap.rb
+++ b/lib/modules/users_ldap.rb
@@ -1,0 +1,39 @@
+require 'net/ldap'
+
+class UsersLDAP
+  # Required function, accepts a KibanaConfig object
+  def initialize(config)
+    @ldap = Net::LDAP.new
+    @ldap.host = (defined? config::Ldap_host) ? config::Ldap_host : "127.0.0.1"
+    @ldap.port = (defined? config::Ldap_port) ? config::Ldap_port : 389
+    @ldap_user_base = (defined? config::Ldap_user_base) ? config::Ldap_user_base : "dc=example, dc=com"
+    @ldap_group_base = (defined? config::Ldap_group_base) ? config::Ldap_group_base : "dc=example, dc=com"
+    @ldap_suffix = (defined? config::Ldap_domain_fqdn) ? "@" + config::Ldap_domain_fqdn : ""
+  end
+
+  # Required function, returns user's groups membership
+  def membership(username)
+    grlist = []
+    return grlist.uniq.sort
+  end
+
+  # Required function, returns a list of all groups
+  def groups()
+    grlist = []
+    return grlist.uniq.sort
+  end
+
+  def del_user(name)
+    return
+  end
+
+  def del_group(name)
+    return
+  end
+end
+
+# Required function, returns the auth
+# class for this module.
+def get_users_module(config)
+  return UsersLDAP.new(config)
+end

--- a/lib/modules/users_pam.rb
+++ b/lib/modules/users_pam.rb
@@ -1,0 +1,57 @@
+require 'etc'
+require 'rpam'
+
+include Rpam
+
+class UsersPam
+  # Required function, accepts a KibanaConfig object
+  def initialize(config)
+  end
+
+  # Required function, returns user's groups membership
+  def membership(username)
+    grlist = []
+    begin
+      userpw = Etc.getpwnam(username)
+    rescue
+      return grlist
+    end
+    begin
+      usergr = Etc.getgrgid(userpw.gid)
+      grlist.push(usergr.name)
+    rescue
+      # This shouldn't happen, if it does it means
+      # someone was probably hand-editing the passwd/
+      # group files and messed up. 
+    end
+    Etc.group { |g|
+      if g.mem.index(username)
+        grlist.push(g.name)
+      end
+    }
+    return grlist.uniq.sort
+  end
+
+  # Required function, returns a list of all groups
+  def groups()
+    grlist = []
+    Etc.group { |g|
+      grlist.push(g.name)
+    }
+    return grlist.uniq.sort
+  end
+
+  def del_user(name)
+    return
+  end
+
+  def del_group(name)
+    return
+  end
+end
+
+# Required function, returns the auth
+# class for this module.
+def get_users_module(config)
+  return UsersPam.new(config)
+end


### PR DESCRIPTION
Sorry for the duplicate. Separated user authentication and identification. You can manage your users and groups (creation/update/permissions/etc) with Kibana (and store them in elasticsearch/whatever you want), but make them authenticate against LDAP for example. 
