### PR TITLE
Allow dots in username

### DIFF
--- a/kibana.rb
+++ b/kibana.rb
@@ -246,7 +246,7 @@ post '/auth/admin/save' do
     params[:Username] = params[:Username].gsub(/^@+/, '')
   end
   # strip illegal characters from username/groupname
-  username = params[:Username].gsub(/[^@0-9A-Za-z_-]/, '')
+  username = params[:Username].gsub(/[^@0-9A-Za-z_\\.-]/, '')
   if username.length < 3
     sleep(1)
     redirect '/auth/admin'


### PR DESCRIPTION
dot is perfectly fine character for at least some auth sources (like LDAP)
