### PR TITLE
Jruby standalone war support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ logstash >= 1.1.0
 elasticsearch >= 0.18.0  
 
 java >= 1.6 if you want to run Kibana in JRuby	
-warble if you want to create an executable standalone war file  
+warbler if you want to create an executable standalone war file  
 
 ## Installation
 Install:  

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ ruby >= 1.8.7 (probably?)
 bundler  
 logstash >= 1.1.0  
 elasticsearch >= 0.18.0  
+
 java >= 1.6 if you want to run Kibana in JRuby	
+warble if you want to create an executable standalone war file  
 
 ## Installation
 Install:  
@@ -42,7 +44,10 @@ Currently you still need Ruby for creating the archive.
 git clone --branch=jruby https://github.com/falkenbt/Kibana.git	
 cd Kibana  	
 Configure your environment (see above). 	
-warble [executable] war	
+rake war  
+or  
+warble executable war  
+if you want to include a webserver (default: winstone).  
 
 Run:	
 	java -jar Kibana.war [--httpPort=5601]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ ruby >= 1.8.7 (probably?)
 bundler  
 logstash >= 1.1.0  
 elasticsearch >= 0.18.0  
+java >= 1.6 if you want to run Kibana in JRuby	
 
 ## Installation
 Install:  
@@ -32,6 +33,21 @@ Run:
 
 Use:  
   Point your browser at http://localhost:5601
+
+## JRuby
+
+To run Kibana with JRuby, e.g. if you have to run in on a windows machine, you can create a (executable) WAR archive.
+Currently you still need Ruby for creating the archive.	
+
+git clone --branch=jruby https://github.com/falkenbt/Kibana.git	
+cd Kibana  	
+Configure your environment (see above). 	
+warble [executable] war	
+
+Run:	
+	java -jar Kibana.war [--httpPort=5601]
+
+Todo: Externalize the configuration. Any help would be appreciated.  
 
 ## FAQ
 Q: Why is there no last button?  

--- a/README.md
+++ b/README.md
@@ -41,16 +41,21 @@ Use:
 To run Kibana with JRuby, e.g. if you have to run in on a windows machine, you can create a (executable) WAR archive.
 Currently you still need Ruby for creating the archive.	
 
+```
 git clone --branch=jruby https://github.com/falkenbt/Kibana.git	
 cd Kibana  	
+gem install bundler  
+bundle install   
+```
+
 Configure your environment (see above). 	
-rake war  
+`rake war  `
 or  
-warble executable war  
+`warble executable war  `
 if you want to include a webserver (default: winstone).  
 
 Run:	
-	java -jar Kibana.war [--httpPort=5601]
+`	java -jar Kibana.war [--httpPort=5601]`
 
 Todo: Externalize the configuration. Any help would be appreciated.  
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,9 @@
 
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'warbler'
+
 
 RSpec::Core::RakeTask.new(:spec)
-
 task :default => [:spec]
+Warbler::Task.new

--- a/config/warble.rb
+++ b/config/warble.rb
@@ -1,0 +1,7 @@
+Warbler::Config.new do |config|
+
+config.dirs = %w(lib)
+
+config.includes = FileList['*.rb']
+
+end

--- a/kibana.gemspec
+++ b/kibana.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rspec-mocks'
+  gem.add_development_dependency 'warbler'
 end

--- a/kibana.gemspec
+++ b/kibana.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |gem|
   gem.version = Kibana::VERSION
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
-  # Dependencies
   gem.add_runtime_dependency 'sinatra'
   gem.add_runtime_dependency 'json'
   gem.add_runtime_dependency 'fastercsv'


### PR DESCRIPTION
I've added support to build a (standalone) WAR archive that can be run in java using warbler. 
Currently you have to edit the KibanaConfig.rb either before packaging the WAR or afterwards by updating in in the WAR. 
Creation and running of WAR tested on Ubuntu using Ruby 1.9.3 and OpenJDK 1.6.0_24.
Running tested on RHEL 5.8, Oracle Java 7 and Windows XP, Oracle Java 1.6.
