### PR TITLE
Add menu entry for help page and links to local help.html (issue #279 )

### DIFF
--- a/public/help.html
+++ b/public/help.html
@@ -6,18 +6,24 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <title>Kibana Help</title>
 
-  <link rel="stylesheet" href="lib/css/jquery-ui-1.8.16.custom.css">
-  <link rel="stylesheet" href="lib/css/jquery.ui.datepicker.css">
   <link rel="stylesheet" href="lib/bootstrap/css/bootstrap.min.css">
   <link rel="stylesheet" href="lib/css/style.css">
   <link rel="stylesheet" href="lib/css/font-awesome.css">
 
   <style type="text/css">
     body {
-    padding-top: 20px;
-    padding-bottom: 20px;
+    padding: 60px;
     }
+
+    .examples {
+    background-color: #EEEEEE;
+    border-radius: 6px 6px 6px 6px;
+    margin-bottom: 10px;
+    padding: 10px;
+    }
+
   </style>
+
   <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon" />
 </head>
 
@@ -32,6 +38,7 @@
           </a>
           <div class="nav-collapse">
             <ul class="nav">
+              <li><a href="index.html">Search</a></li>
               <li class="active"><a href="help.html">Documentation</a></li>
               <li><a href="https://lucene.apache.org/core/old_versioned_docs/versions/3_5_0/queryparsersyntax.html" target="_blank">Apache Lucene</a></li>
               <li><a href="http://kibana.org/index.html" target="_blank">Kibana Home</a></li>
@@ -43,27 +50,25 @@
       </div>
     </div>
 
-      <div id=main>
-        <div>
-            <div id=graph>
-              <div class=hero-unit>
-                <h1><img src=images/kibana_banner.png></h1>
-                <br><br>
-                <p><strong>Welcome to <a href="http://kibana.org/index.html" target="_blank">Kibana</a></strong> a user friendly way to view, search and visualize your log data.</p>
-                <p>Some useful query examples:</p>
-                <p>4.3.2.1 AND 1.2.3.4<br>
-                4.3.2.1 AND NOT 1.2.3.4<br>
-                *kibana.org*</p>
-                <p>Learn lots more about 
-                <a rel="nofollow" href="https://lucene.apache.org/core/old_versioned_docs/versions/3_5_0/queryparsersyntax.html" target="_blank">Lucene query syntax</a> 
-                at the <a rel="nofollow" href="https://lucene.apache.org" target="_blank">Apache Lucene</a> and <a rel="nofollow" href="http://kibana.org/about.html" target="_blank">Kibana</a> Project page.</p>
-                <br>
-                <footer>
-                  <p>&copy; Rashid Khan 2012. Visual style provided by <a href="http://twitter.github.com/bootstrap">Twitter Bootstrap</a>. Icons provided by <a href="http://www.glyphicons.com">Glyphicons</a>.</p>
-                </footer>
-              </div>
-            </div>
-        </div>
+    <div id=main>
+      <h1><img src=images/kibana_banner.png></h1>
+      <br><br>
+      <p><strong>Welcome to <a href="http://kibana.org/index.html" target="_blank">Kibana</a></strong> a user friendly way to view, search and visualize your log data.</p>
+      <p>Some useful query examples:</p>
+      <div class="examples">
+        <p>4.3.2.1 AND 1.2.3.4<br>
+        4.3.2.1 AND NOT 1.2.3.4<br>
+        *kibana.org*</p>
       </div>
-  </body>
+      <p>Learn lots more about 
+      <a rel="nofollow" href="https://lucene.apache.org/core/old_versioned_docs/versions/3_5_0/queryparsersyntax.html" target="_blank">Lucene query syntax</a> 
+      at the <a rel="nofollow" href="https://lucene.apache.org" target="_blank">Apache Lucene</a> and <a rel="nofollow" href="http://kibana.org/about.html" target="_blank">Kibana</a> Project page.</p>
+    </div>
+</body>
+
+<footer>
+  <hr>
+  &copy; Rashid Khan 2012. Visual style provided by <a href="http://twitter.github.com/bootstrap">Twitter Bootstrap</a>. Icons provided by <a href="http://www.glyphicons.com">Glyphicons</a>.
+</footer>
+
 </html>

--- a/public/help.html
+++ b/public/help.html
@@ -14,16 +14,13 @@
     body {
     padding: 60px;
     }
-
     .examples {
     background-color: #EEEEEE;
     border-radius: 6px 6px 6px 6px;
     margin-bottom: 10px;
     padding: 10px;
     }
-
   </style>
-
   <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon" />
 </head>
 
@@ -68,7 +65,7 @@
 
 <footer>
   <hr>
-  &copy; Rashid Khan 2012. Visual style provided by <a href="http://twitter.github.com/bootstrap">Twitter Bootstrap</a>. Icons provided by <a href="http://www.glyphicons.com">Glyphicons</a>.
+  &copy; Rashid Khan 2012. Provided by <a href="http://kibana.org/index.html" target="_blank">http://kibana.org</a>.
 </footer>
 
 </html>

--- a/public/help.html
+++ b/public/help.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>Kibana Help</title>
+
+  <link rel="stylesheet" href="lib/css/jquery-ui-1.8.16.custom.css">
+  <link rel="stylesheet" href="lib/css/jquery.ui.datepicker.css">
+  <link rel="stylesheet" href="lib/bootstrap/css/bootstrap.min.css">
+  <link rel="stylesheet" href="lib/css/style.css">
+  <link rel="stylesheet" href="lib/css/font-awesome.css">
+
+  <style type="text/css">
+    body {
+    padding-top: 20px;
+    padding-bottom: 20px;
+    }
+  </style>
+  <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon" />
+</head>
+
+<body>
+   <div class="navbar navbar-fixed-top navbar-inverse">
+      <div class="navbar-inner">
+        <div class="container">
+          <a data-target=".nav-collapse" data-toggle="collapse" class="btn btn-navbar">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </a>
+          <div class="nav-collapse">
+            <ul class="nav">
+              <li class="active"><a href="help.html">Documentation</a></li>
+              <li><a href="https://lucene.apache.org/core/old_versioned_docs/versions/3_5_0/queryparsersyntax.html" target="_blank">Apache Lucene</a></li>
+              <li><a href="http://kibana.org/index.html" target="_blank">Kibana Home</a></li>
+              <li><a href="http://kibana.org/about.html" target="_blank">About Kibana</a></li>
+              <li><a href="http://kibana.org/contact.html" target="_blank">Kibana Support</a></li>
+            </ul>
+          </div><!--/.nav-collapse -->
+        </div>
+      </div>
+    </div>
+
+      <div id=main>
+        <div>
+            <div id=graph>
+              <div class=hero-unit>
+                <h1><img src=images/kibana_banner.png></h1>
+                <br><br>
+                <p><strong>Welcome to <a href="http://kibana.org/index.html" target="_blank">Kibana</a></strong> a user friendly way to view, search and visualize your log data.</p>
+                <p>Some useful query examples:</p>
+                <p>4.3.2.1 AND 1.2.3.4<br>
+                4.3.2.1 AND NOT 1.2.3.4<br>
+                *kibana.org*</p>
+                <p>Learn lots more about 
+                <a rel="nofollow" href="https://lucene.apache.org/core/old_versioned_docs/versions/3_5_0/queryparsersyntax.html" target="_blank">Lucene query syntax</a> 
+                at the <a rel="nofollow" href="https://lucene.apache.org" target="_blank">Apache Lucene</a> and <a rel="nofollow" href="http://kibana.org/about.html" target="_blank">Kibana</a> Project page.</p>
+                <br>
+                <footer>
+                  <p>&copy; Rashid Khan 2012. Visual style provided by <a href="http://twitter.github.com/bootstrap">Twitter Bootstrap</a>. Icons provided by <a href="http://www.glyphicons.com">Glyphicons</a>.</p>
+                </footer>
+              </div>
+            </div>
+        </div>
+      </div>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -32,14 +32,23 @@
   <link rel="stylesheet" href="lib/bootstrap/css/bootstrap.min.css">
   <link rel="stylesheet" href="lib/css/style.css">
   <link rel="stylesheet" href="lib/css/font-awesome.css">
-  
 
   <style type="text/css">
     body {
     padding-top: 55px;
     padding-bottom: 40px;
     }
+    footer {
+    padding-top: 10px;
+    }
+    .confidential {
+    background-color: #EEEEEE;
+    border-radius: 6px 6px 6px 6px;
+    margin-bottom: 10px;
+    padding: 10px;
+    }
   </style>
+
   <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon" />
 
 </head>
@@ -101,9 +110,20 @@
           <div id=legend></div>
         </div>
         <div id=logs class=zebra-stripped></div>
+        <footer>
+          <div class="confidential">
+            <p><strong>Confidential Information</strong></p>
+            <p>All of provided reports contains company confidential information. Do not distribute, email, fax, or transfer via any electronic mechanism
+               unless it has been approved by the recipient company's security policy. All copies and backups of this documents should be saved on protected
+               storage at all times. Do not share any of the information contained within this reports with anyone unless they are authorized to view the
+               information. Violating any of the previous instructions is grounds for termination.</p>
+          </div>
+          &copy; Rashid Khan 2012. Provided by <a href="http://kibana.org/index.html" target="_blank">http://kibana.org</a>.
+        </footer>
       </div>
     </div>
   </div>
 
-  </body>
+</body>
+
 </html>

--- a/public/lib/js/ajax.js
+++ b/public/lib/js/ajax.js
@@ -1085,7 +1085,9 @@ function feedLinks(obj) {
     "<a href=export/" + Base64.encode(JSON.stringify(obj, null, '')) + ">export " +
     "<i class='icon-hdd'></i></a> "+
     "<a href=stream#" + Base64.encode(JSON.stringify(obj, null, '')) + ">stream " +
-    "<i class='icon-dashboard'></i></a>"
+    "<i class='icon-dashboard'></i></a> "+
+    "<a href=help.html target=_blank>help " +
+    "<i class='icon-book'></i></a>"
 }
 
 $(function () {


### PR DESCRIPTION
Add simple help page: /help.html

Only one code changes for a help-menu entry in function feedLinks(obj)
/public/lib/js/ajax.jsajax.js

![help-menu](https://f.cloud.github.com/assets/3251642/121532/22615c4a-6db1-11e2-9fc8-cec8d26e2adb.JPG)
