### PR TITLE
Bump Rack version in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     jruby-jars (1.7.2)
     jruby-rack (1.1.13.1)
     json (1.7.5)
-    rack (1.4.1)
+    rack (1.4.5)
     rack-protection (1.2.0)
       rack
     rake (10.0.3)


### PR DESCRIPTION
This fixes the recently announced vulnerabilities in Rack for a timing attack on sessions and a subsequent remote code execution vulnerability (CVE-2013-0263) as well as a path traversal vulnerability (CVE-2013-0262).

All of these vulnerabilities are in Rack only which Kibana uses as a dependency through Sinatra.

As a side-remark: I upgraded rack conservatively. Sinatra should be able to also support Rack 1.5.2. But as I don't know what other dependencies expect, I though to play it safe :)
