### PR TITLE
Let WARbler run under JRuby, and switch embedded webserver to jetty.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 KibanaConfig.rbackup.rb
 *.DS_Store
 /tmp/*
+Kibana.war

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Configure your environment (see above).
 `jruby -S rake war  `
 or  
 `jruby -S warble executable war  `
-if you want to include a webserver (default: winstone).  
+if you want to include a webserver (default: jetty).  
 
 Run:	
-`	java -jar Kibana.war [--httpPort=5601]`
+`	java [-Djetty.port=5601] -jar Kibana.war`
 
 Todo: Externalize the configuration. Any help would be appreciated.  
 

--- a/README.md
+++ b/README.md
@@ -39,19 +39,18 @@ Use:
 ## JRuby
 
 To run Kibana with JRuby, e.g. if you have to run in on a windows machine, you can create a (executable) WAR archive.
-Currently you still need Ruby for creating the archive.	
 
 ```
 git clone --branch=kibana-ruby https://github.com/rashidkpc/Kibana.git	
 cd Kibana  	
-gem install bundler  
-bundle install   
+jruby -S gem install bundler  
+jruby -S bundle install   
 ```
 
 Configure your environment (see above). 	
-`rake war  `
+`jruby -S rake war  `
 or  
-`warble executable war  `
+`jruby -S warble executable war  `
 if you want to include a webserver (default: winstone).  
 
 Run:	

--- a/config/warble.rb
+++ b/config/warble.rb
@@ -1,7 +1,7 @@
 Warbler::Config.new do |config|
 
 config.dirs = %w(lib)
-
+config.webserver = "jetty"
 config.includes = FileList['*.rb']
 
 end

--- a/kibana.gemspec
+++ b/kibana.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'fastercsv'
   gem.add_runtime_dependency 'daemons'
   gem.add_runtime_dependency 'tzinfo'
-  gem.add_runtime_dependency 'thin'
+  gem.add_runtime_dependency 'thin' unless RUBY_PLATFORM =~ /java/i
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
Sorry if this has conflated 2 different requests (I'm a sysadmin, not a coder).

Dropping the thin requirement save a Mb or 2 spinning an executable WARfile, and
'jruby -S bundle install' works fine too.
