### PR TITLE
Add filter fields action on logs 

### DIFF
--- a/public/lib/js/ajax.js
+++ b/public/lib/js/ajax.js
@@ -915,6 +915,8 @@ function details_table(objid,theme) {
     var buttons = "<span class='raw'>" + xmlEnt(value) + "</span>" +
       "<i class='jlink icon-large icon-search msearch' " +
       "data-action='' data-field='"+field+"'></i> " +
+      "<i class='jlink icon-large icon-filter msearch' " +
+      "data-action='FILTER ' data-field='"+field+"'></i> " +
       "<i class='jlink icon-large icon-ban-circle msearch' " +
       "data-action='NOT ' data-field='"+field+"'></i> ";
 
@@ -991,7 +993,12 @@ function mSearch(field, value, mode) {
     var query = field + ":" + "\"" + addslashes(value.toString()) + "\"";
   }
   var glue = queryinput != "" ? " AND " : " ";
-  window.hashjson.search = queryinput + glue + query;
+  if (query.indexOf('FILTER') !== -1) {
+    window.hashjson.search = query.slice(7);
+  }
+  else {
+    window.hashjson.search = queryinput + glue + query;
+  }
   setHash(window.hashjson);
   scroll(0, 0);
 }

--- a/public/lib/js/ajax.js
+++ b/public/lib/js/ajax.js
@@ -927,7 +927,7 @@ function details_table(objid,theme) {
     if (resultjson.kibana.clickable_urls) {
       var value = value === undefined ? "-" : value.toString();
       // Detect URLs and inserts delimiters
-      var value = value.replace(RegExp("(https?://([-\\w\\.]+)+(:\\d+)?(/([\\w/_\\.]*(\\?\\S+)?)?)?)", "g"),
+      var value = value.replace(RegExp("(https?://([-\\w\\.]+)+(:\\d+)?(/([\\,-\\w/_\\.]*(\\?\\S+)?)?)?)", "g"),
         function (all, text, char) {
           return "@KIBANA_LINK_START@" + text + "@KIBANA_LINK_END@";
         }


### PR DESCRIPTION
Hello

When you're browsing logs, searching with a field, refining and refining your query, sometimes you need to re-query with just one of the field of one of your previous results.
So I added a "filter" action that cleans previous query parameters and use this only field to build the query.

Use case : find some errors in your distributed system, refine with just one source type and then want to see the whole path of the request with one uuid field

TODO : refactor code / add this features to every popup that contains an action (analysis, trend, etc...)

Bonus : I've fixed URL highlighting for URLs containing "," and "-"
