### PR TITLE
Kibana ruby auth

### DIFF
--- a/KibanaConfig.rb
+++ b/KibanaConfig.rb
@@ -135,6 +135,16 @@ module KibanaConfig
   Ldap_port = 389
   # Adds a '@domain.local' suffix to the username when authenticating against an LDAP directory
   # Ldap_domain_fqdn = 'domain.local'
+  # DNs that contain users and groups
+  # Ldap_user_base = 'ou=Users,dc=example,dc=com'
+  # Ldap_group_base = 'ou=Groups,dc=example,dc=com'
+
+  # In order to bind with a full DN, not just a bare username, set Ldap_user_attribute to the attribute that contains the username
+  # Ldap_user_attribute = 'uid'
+  # Will attempt to authenticate with the DN:
+  #   Ldap_user_attribute=username,Ldap_user_base
+  # so, to use the examples given:
+  #   uid=username,ou=Users,dc=example,dc=com
 
   # Storage Module
   Storage_module = 'elasticsearch'  # mongo

--- a/lib/modules/auth_ldap.rb
+++ b/lib/modules/auth_ldap.rb
@@ -25,6 +25,10 @@ class AuthLDAP
   # Required function, authenticates a username/password
   def authenticate(username,password)
     begin
+      if username == @auth_admin_user and password == @auth_admin_pass
+        puts "Bypassing LDAP authentication for Auth_Admin_User"
+        return true
+      end
       @ldap.auth @ldap_prefix + username + @ldap_suffix, password
       if @ldap.bind
         return true

--- a/lib/modules/auth_ldap.rb
+++ b/lib/modules/auth_ldap.rb
@@ -8,13 +8,24 @@ class AuthLDAP
     @ldap.port = (defined? config::Ldap_port) ? config::Ldap_port : 389
     @ldap_user_base = (defined? config::Ldap_user_base) ? config::Ldap_user_base : "dc=example, dc=com"
     @ldap_group_base = (defined? config::Ldap_group_base) ? config::Ldap_group_base : "dc=example, dc=com"
-    @ldap_suffix = (defined? config::Ldap_domain_fqdn) ? "@" + config::Ldap_domain_fqdn : ""
+    if (defined? config::Ldap_domain_fqdn)
+      @ldap_suffix = "@" + config::Ldap_domain_fqdn
+      @ldap_prefix = ""
+    elsif (defined? config::Ldap_user_attribute)
+      @ldap_suffix = "," + @ldap_user_base
+      @ldap_prefix = config::Ldap_user_attribute + "="
+    else
+      @ldap_suffix = ""
+      @ldap_prefix = ""
+    end
+    @auth_admin_user = (defined? config::Auth_Admin_User) ? config::Auth_Admin_User : ""
+    @auth_admin_pass = (defined? config::Auth_Admin_Pass) ? config::Auth_Admin_Pass : ""
   end
 
   # Required function, authenticates a username/password
   def authenticate(username,password)
     begin
-      @ldap.auth username + @ldap_suffix, password
+      @ldap.auth @ldap_prefix + username + @ldap_suffix, password
       if @ldap.bind
         return true
       end


### PR DESCRIPTION
The existing kibana-ruby-auth ldap module only allowed authentication with a bare username.  This diff adds support for one common way that bindDNs are formulated.

Also, I added a bypass to LDAP authentication for the Auth_Admin_User.  Without this, you have to run Kibana once with auth_elasticsearch in order to set up a local account for an LDAP user, give that user admin rights, and then change to auth_ldap.
