### PR TITLE
Support for local gem repository

### DIFF
--- a/kibana.rb
+++ b/kibana.rb
@@ -1,6 +1,7 @@
 $:.unshift(File.expand_path(File.join(File.dirname(__FILE__), "lib")))
 
 require 'rubygems'
+require 'bundler/setup'
 require 'kibana'
 
 KibanaApp.run!


### PR DESCRIPTION
When installing the dependencies in a local repository (using something like `bundle install --path vendor/bundle`) Kibana fails to recognize these because `bundler/setup` is not loaded.

I rarely venture into Ruby territory, so this change may break things. Works for me though.
