### PR TITLE
bump eventmachine to 1.0.1 for ruby 2.0.0 support.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
   specs:
     daemons (1.1.9)
     diff-lcs (1.1.3)
-    eventmachine (1.0.0)
+    eventmachine (1.0.1)
     fastercsv (1.5.5)
     jruby-jars (1.7.2)
     jruby-rack (1.1.13.1)


### PR DESCRIPTION
eventmachine 1.0.0 does not work with ruby 2.0.0, this change gives kibana ruby 2.0.0 compatibility.
