### PR TITLE
Fixed Nil error for nested fields

### DIFF
--- a/lib/kelastic.rb
+++ b/lib/kelastic.rb
@@ -132,7 +132,7 @@ class Kelastic
 
     def collect_item_attributes(h,field)
       r = []
-      field = field.sub(".",".properties.")
+      field = field.gsub("\.",".properties.")
       types = h.sort_by { |k,v| v }[0][1]
       types.each do | type |
         r << field.split(".",3).inject(type[1]['properties']) { |hash, key|


### PR DESCRIPTION
Fields with multiple dots (e.g. "@fields.data.timeTaken") caused a Nil error in field_type due to collect_item_attributes returning an empty array.
This happens because the field string only substituted the first dot.  Converting from "sub" to "gsub" resolved the issue.
