### PR TITLE
Update KibanaConfig.rb

### DIFF
--- a/KibanaConfig.rb
+++ b/KibanaConfig.rb
@@ -22,9 +22,7 @@ module KibanaConfig
   # Elasticsearch = "#{es_ip}:#{es_port}"
   # KibanaPort = ENV['KIBANA_PORT'] ? ENV['KIBANA_PORT'] : 5601
   # KibanaHost = ENV['KIBANA_HOST'] ? ENV['KIBANA_HOST'] : 'localhost'
-
-  #Set the Net::HTTP read/open timeouts for the connection to the ES backend
-  ElasticsearchTimeout = 500
+  
 
   # The record type as defined in your logstash configuration.
   # Seperate multiple types with a comma, no spaces. Leave blank


### PR DESCRIPTION
Removed a duplicate ElasticsearchTimeout = 500 in the KibanaConfig.rb which was causing a warning on start-up. 
