### PR TITLE
set correct mime type for json queries

### DIFF
--- a/lib/kibana-app.rb
+++ b/lib/kibana-app.rb
@@ -49,6 +49,8 @@ class KibanaApp < Sinatra::Base
 
   # Returns
   get '/api/search/:hash/?:segment?' do
+    content_type :json
+
     segment = params[:segment].nil? ? 0 : params[:segment].to_i
 
     req     = ClientRequest.new(params[:hash])
@@ -72,6 +74,8 @@ class KibanaApp < Sinatra::Base
   end
 
   get '/api/graph/:mode/:interval/:hash/?:segment?' do
+    content_type :json
+
     segment = params[:segment].nil? ? 0 : params[:segment].to_i
 
     req     = ClientRequest.new(params[:hash])
@@ -90,6 +94,8 @@ class KibanaApp < Sinatra::Base
   end
 
   get '/api/id/:id/:index' do
+    content_type :json
+
     ## TODO: Make this verify that the index matches the smart index pattern.
     id      = params[:id]
     index   = "#{params[:index]}"
@@ -99,6 +105,8 @@ class KibanaApp < Sinatra::Base
   end
 
   get '/api/analyze/:field/trend/:hash' do
+    content_type :json
+
     limit = KibanaConfig::Analyze_limit
     show  = KibanaConfig::Analyze_show
     req           = ClientRequest.new(params[:hash])
@@ -151,6 +159,8 @@ class KibanaApp < Sinatra::Base
   end
 
   get '/api/analyze/:field/terms/:hash' do
+    content_type :json
+
     limit   = KibanaConfig::Analyze_show
     req     = ClientRequest.new(params[:hash])
     fields = Array.new
@@ -169,6 +179,8 @@ class KibanaApp < Sinatra::Base
   end
 
   get '/api/analyze/:field/score/:hash' do
+    content_type :json
+
     limit = KibanaConfig::Analyze_limit
     show  = KibanaConfig::Analyze_show
     req     = ClientRequest.new(params[:hash])
@@ -199,6 +211,8 @@ class KibanaApp < Sinatra::Base
   end
 
   get '/api/analyze/:field/mean/:hash' do
+    content_type :json
+
     req     = ClientRequest.new(params[:hash])
     query   = StatsFacet.new(req.search,req.from,req.to,params[:field])
     indices = Kelastic.index_range(req.from,req.to,KibanaConfig::Facet_index_limit)
@@ -218,6 +232,8 @@ class KibanaApp < Sinatra::Base
   end
 
   get '/api/stream/:hash/?:from?' do
+    content_type :json
+
     # This is delayed by 10 seconds to account for indexing time and a small time
     # difference between us and the ES server.
     delay = 10

--- a/public/lib/js/ajax.js
+++ b/public/lib/js/ajax.js
@@ -105,7 +105,7 @@ function getPage() {
       // Make sure we're still on the same page
       if (sendhash == encodeURIComponent(window.location.hash.replace(/^#/, ''))) {
         //Parse out the result
-        window.resultjson = JSON.parse(json);
+        window.resultjson = json;
 
         //console.log(
         //  'curl -XGET \'http://localhost:9200/'+resultjson.index+
@@ -218,7 +218,7 @@ function getGraph(interval) {
       if (sendhash == encodeURIComponent(window.location.hash.replace(/^#/, ''))) {
 
         //Parse out the returned JSON
-        var graphjson = JSON.parse(json);
+        var graphjson = json;
 
         if ($(".legend").length > 0) {
           window.graphdata = graphjson.facets[mode].entries.concat(
@@ -309,7 +309,7 @@ function getID() {
     type: "GET",
     cache: false,
     success: function (json) {
-      window.resultjson = JSON.parse(json)
+      window.resultjson = json
       var hit = resultjson.hits.hits[0]
       blank_page();
       setMeta(1);
@@ -347,7 +347,7 @@ function getAnalysis() {
 
         //Parse out the returned JSON
         var field = window.hashjson.analyze_field;
-        resultjson = JSON.parse(json);
+        resultjson = json;
 
         $('.pagelinks').html('');
         $('#fields').html('');


### PR DESCRIPTION
For reasons I won't bore you with, I'm double-proxying my Kibana installation and using `mod_proxy_html` to do some rewrites.  This was messing up the JSON from Kibana because the MIME type was coming back as `text/html`.  I've set the type explicitly, which has the side-effect of simplifying `ajax.js` ever-so-slightly.
