### PR TITLE
Add clarification about use of Time_format

### DIFF
--- a/KibanaConfig.rb
+++ b/KibanaConfig.rb
@@ -40,6 +40,10 @@ module KibanaConfig
 
   # Format for timestamps. Defaults to mm/dd HH:MM:ss.
   # For syntax see: http://blog.stevenlevithan.com/archives/date-time-format
+  #
+  # Do not use isoUtcDatetime or the "UTC:" prefix described in the above
+  # article, as timezone correction is already performed by the "Timezone"
+  # config variable.
   # Time_format = 'isoDateTime' 
   Time_format = 'mm/dd HH:MM:ss'
 


### PR DESCRIPTION
Specifying `isoUtcDatetime` or `UTC:` prefix in here causes display issues. Some (but not all!?) datetimes are adjusted for timezone differences twice. We had `Timezone = 'UTC'` and `Time_format = 'isoUtcDatetime'` which resulted in the `Time` column displaying UTC-1 with UTC timestamps and a UTC+1 browser.
