### PR TITLE
fix a problem with maxDatetime badly initialized when TZ is set

### DIFF
--- a/public/lib/js/ajax.js
+++ b/public/lib/js/ajax.js
@@ -1162,7 +1162,7 @@ function datepickers(from,to) {
 
   $('#timeto').datetimeEntry({
     minDatetime: $('#timefrom').datetimeEntry('getDatetime'),
-    maxDatetime: utc_date_obj(new Date()),
+    maxDatetime: utc_date_obj(new Date(to - tOffset)),
     datetimeFormat: 'Y-O-D H:M:S',
     spinnerImage: ''
   },to);


### PR DESCRIPTION
Hi,

I encountered a minor problem: when using timezone that is not GMT/UTC, either set to config or via the browser, the "to" datepicker is initialized with a max value set to UTC, which makes impossible for me to choose a time close to now().

I don't know JS, so  maybe my patch isn't so good, but you got the idea.

Hope this helps,
## 

rémi
