### PR TITLE
Use getlocal instead of getutc.

### DIFF
--- a/lib/kelastic.rb
+++ b/lib/kelastic.rb
@@ -64,10 +64,10 @@ class Kelastic
         for index in index_pattern do
           step_time = from
           begin
-            requested << step_time.getutc.strftime(index)
+            requested << step_time.getlocal.strftime(index)
           end while (step_time += KibanaConfig::Smart_index_step) <= to
-          unless requested.include? to.getutc.strftime(index)
-            requested << to.getutc.strftime(index)
+          unless requested.include? to.getlocal.strftime(index)
+            requested << to.getlocal.strftime(index)
           end
         end
 


### PR DESCRIPTION
Hi,

I have a problem in the Kibana search which don't returns the good index after midnight because of timezone.

For example : My event is created with the timestamp "2013-04-30 00:28:01 +0200". I would like to see the event in Kibana, but it search in logstash-2013-04-29 (yesterday), no in logstash-2013-04-30 (today).

I change getutc to getlocal and it works. Is there a reason to use getutc ?
