### PR TITLE
Update ajax.js

### DIFF
--- a/public/lib/js/ajax.js
+++ b/public/lib/js/ajax.js
@@ -1162,7 +1162,7 @@ function datepickers(from,to) {
 
   $('#timeto').datetimeEntry({
     minDatetime: $('#timefrom').datetimeEntry('getDatetime'),
-    maxDatetime: utc_date_obj(new Date()),
+    maxDatetime: to_date,
     datetimeFormat: 'Y-O-D H:M:S',
     spinnerImage: ''
   },to);


### PR DESCRIPTION
Fixed timezone management for "timeto" control. This was previously set to have a maximum which was in UTC. Its now set to "to_date" which includes the time offset for the local timezone.
