### PR TITLE
serve js/timezone.js with 'application/javascript' mime type instead of ...

### DIFF
--- a/kibana.rb
+++ b/kibana.rb
@@ -615,5 +615,6 @@ delete '/api/favorites' do
 end
 
 get '/js/timezone.js' do
+  content_type 'application/javascript'
   erb :timezone
 end


### PR DESCRIPTION
...default ('text/html')

Google Chrome seems to have tightened execution security and hence the timezone.js served as 'text/html' will not be executed.

To fix this, the content type is set explicitly.
