### PR TITLE
Switching call to protected 'offset' method

### DIFF
--- a/views/timezone.erb
+++ b/views/timezone.erb
@@ -1,6 +1,6 @@
 var tmp_offset = "<%="#{
 	KibanaConfig::Timezone == 'user' ?
-	'user' : ((TZInfo::Timezone.get(KibanaConfig::Timezone).current_period.offset.utc_total_offset).to_f / 3600.0).to_s
+	'user' : ((TZInfo::Timezone.get(KibanaConfig::Timezone).current_period.utc_total_offset).to_f / 3600.0).to_s
 }"%>"
 
 window.time_format = "<%= defined?(KibanaConfig::Time_format) ? KibanaConfig::Time_format : "mm/dd HH:MM:ss" %>"


### PR DESCRIPTION
in TZInfo 1.0 offset was made protected.  Using utc_total_offset() method instead of offset.utc_total_offset

I have no idea why on a particular set of machines, when I run bundle install, it uses tzinfo 1.0.1 instead of 0.3.35 specified in Gemfile.lock.  I'm too new to Ruby unfortunately....

See: Issue #370 
