### PR TITLE
Fixes broken links when using URLs like http://host/kibana

### DIFF
--- a/public/lib/js/stream.js
+++ b/public/lib/js/stream.js
@@ -89,7 +89,7 @@ function getStream() {
             }
             ));
 
-          var jlink = $('<a/>').addClass('jlink').attr('href', "../#" + hash).html($('<i/>').addClass('icon-link'));
+          var jlink = $('<a/>').addClass('jlink').attr('href', location.href.substring( 0, location.href.indexOf( "/stream#") ) + "/#" + hash).html($('<i/>').addClass('icon-link'));
           var linkTableData = $("<td/>").css('white-space', 'nowrap');
           linkTableData.text(prettyDateString(Date.parse(get_field_value(hit,'@timestamp')) + tOffset)).prepend(jlink);
           tableRow.append(linkTableData);


### PR DESCRIPTION
Fixes bad links when using a reverse proxy and a sub-directory like this Apache config:

ProxyPreserveHost On
ProxyPass /kibana/ http://localhost:5601/
ProxyPassReverse /kibana/ http://localhost:5601/

Links to events are currently pointing to the root (/#eventid) and not to the sub-directory (/kibana/#eventid).
