### PR TITLE
Fixing millisecond display in Firefox

### DIFF
--- a/public/lib/js/lib/date.js
+++ b/public/lib/js/lib/date.js
@@ -76,7 +76,7 @@ var dateFormat = function () {
 		}
 
 		// Passing date through Date applies Date.parse, if necessary
-		date = date ? new Date(date) : new Date;
+		date = date ? new Date(date.valueOf()) : new Date;
 
 		if (isNaN(date)) throw SyntaxError("invalid date");
 


### PR DESCRIPTION
new Date(date) is not defined so (according to spec) Firefox will use toString() on the date which drops the milliseconds.  Chrome diverges from this to keep milliseconds.  https://bugs.ecmascript.org/show_bug.cgi?id=1257
